### PR TITLE
More stuff

### DIFF
--- a/src/curry.js
+++ b/src/curry.js
@@ -1,0 +1,15 @@
+export function createElementCurry (single) {
+  return function (a, b) {
+    if (arguments.length === 2) {
+      return function (el) {
+        single(el, a, b);
+      }
+    } else {
+      return function (el) {
+        for (var key in a) {
+          single(el, key, a[key]);
+        }
+      }
+    }
+  }
+}

--- a/src/el.js
+++ b/src/el.js
@@ -59,9 +59,13 @@ function expand (templateElement) {
       arg = arg(element);
     }
 
-    if (empty && (typeof arg === 'string' || typeof arg === 'number')) {
-      element.textContent = arg;
-      empty = false;
+    if (typeof arg === 'string' || typeof arg === 'number') {
+      if (empty) {
+        element.textContent = arg;
+      } else {
+        element.appendChild(document.createTextNode(arg));
+        empty = false;
+      }
       continue;
     }
 

--- a/src/el.js
+++ b/src/el.js
@@ -20,10 +20,6 @@ export function el (query, a, b, c, d, e, f) {
   }
 
   if (typeof query === 'function') {
-    if (query.constructor) {
-      // ?
-    }
-
     return len === 1 ? new query()
          : len === 2 ? new query(a)
          : len === 3 ? new query(a, b)
@@ -62,9 +58,9 @@ function expand (templateElement) {
     if (typeof arg === 'string' || typeof arg === 'number') {
       if (empty) {
         element.textContent = arg;
+        empty = false;
       } else {
         element.appendChild(document.createTextNode(arg));
-        empty = false;
       }
       continue;
     }

--- a/src/el.js
+++ b/src/el.js
@@ -49,12 +49,6 @@ function expand (templateElement) {
   for (var i = 1; i < arguments.length; i++) {
     var arg = arguments[i];
 
-    if (arg == null) continue;
-
-    if (typeof arg === 'function') {
-      arg = arg(element);
-    }
-
     if (typeof arg === 'string' || typeof arg === 'number') {
       if (empty) {
         element.textContent = arg;
@@ -65,12 +59,16 @@ function expand (templateElement) {
       continue;
     }
 
-    if (mount(element, arg)) {
-      empty = false;
-      continue;
+    if (typeof arg === 'function') {
+      arg = arg(element);
     }
 
-    if (typeof arg === 'object') {
+    // null guard before we attempt to mount
+    if (arg == null) continue;
+
+    if (mount(element, arg)) {
+      empty = false;
+    } else {
       for (var attr in arg) {
         var value = arg[attr];
 

--- a/src/mount.js
+++ b/src/mount.js
@@ -19,19 +19,7 @@ export function mount (parent, child, before) {
 
   var childEl = child.el || child;
 
-  if (typeof child === 'string' || typeof child === 'number') {
-    doMount(parentEl, text(child), before);
-    return true;
-  } else if (child.views) {
-    child.parent = parent;
-    setChildren(parentEl, child.views);
-    return true;
-  } else if (child.length) {
-    for (var i = 0; i < child.length; i++) {
-      mount(parent, child[i], before);
-    }
-    return true;
-  } else if (childEl.nodeType) {
+  if (childEl.nodeType) {
     if (child !== childEl) {
       childEl.view = child;
     }
@@ -45,6 +33,15 @@ export function mount (parent, child, before) {
       childEl.mounted = true;
       child.mount && child.mount();
       notifyMountDown(childEl);
+    }
+    return true;
+  } else if (child.views) {
+    child.parent = parent;
+    setChildren(parentEl, child.views);
+    return true;
+  } else if (child.length) {
+    for (var i = 0; i < child.length; i++) {
+      mount(parent, child[i], before);
     }
     return true;
   }

--- a/src/mount.js
+++ b/src/mount.js
@@ -12,11 +12,6 @@ function doMount (parent, child, before) {
 
 export function mount (parent, child, before) {
   var parentEl = parent.el || parent;
-
-  if (child == null) {
-    return;
-  }
-
   var childEl = child.el || child;
 
   if (childEl.nodeType) {

--- a/src/on.js
+++ b/src/on.js
@@ -1,14 +1,7 @@
-export function on (eventHandlers) {
-  return function (el) {
-    for (var key in eventHandlers) {
-      addHandler(el, key, eventHandlers[key]);
-    }
-    return;
-  }
-}
+import { createElementCurry } from './curry';
 
-function addHandler (el, key, handler) {
-  el.addEventListener(key, function (e) {
-    handler.call(el.view, e);
+export var on = createElementCurry(function (el, event, callback) {
+  el.addEventListener(event, function (e) {
+    callback.call(el.view, e);
   });
-}
+});

--- a/src/text.js
+++ b/src/text.js
@@ -1,1 +1,3 @@
-export var text = document.createTextNode.bind(document);
+export function text (content) {
+  return document.createTextNode(content);
+}


### PR DESCRIPTION
- Add support for `on('event', callback)`, #14 (do we have any other curry functions?)
- Changed `text` to be a function call instead of a bind to allow V8 to inline it.
- Removed `String` and `Number` support from `mount`❗ They are now handled entirely within `expand`, this avoids logic duplication and doing unnecessary work where a text node would be checked for `mount`, child elements, etc. Feel free to object here, although I didn't think `mount(document.body, 'foo')` is something someone would want to do 🤔.

```
Benching REDOM <div> with el()
7686ns per iteration (130107 ops/sec)

Benching REDOM <div> with precached elements
6861ns per iteration (145746 ops/sec)
```

Starting to wonder where we can _remove_ some code...