### PR TITLE
support css selector shorthand for svg elements

### DIFF
--- a/src/create-element.js
+++ b/src/create-element.js
@@ -50,7 +50,11 @@ export function createElement (query, ns) {
   }
 
   if (className) {
-    element.className = className;
+    if (ns) {
+      element.setAttribute('class', className)
+    } else {
+      element.className = className;
+    }
   }
 
   return element;


### PR DESCRIPTION
allows for stuff like: svg('svg.icon', svg('path.red-line'))